### PR TITLE
[feat] 헤더 레이아웃 작업

### DIFF
--- a/src/components/Layout/HeaderLayout/index.tsx
+++ b/src/components/Layout/HeaderLayout/index.tsx
@@ -8,7 +8,7 @@ function HeaderLayout({ children }: HeaderLayoutProps) {
   return (
     <>
       <header>추후 헤더 완성되면 만들어진 헤더 사용 예정 </header>
-      <main>{children}</main>
+      {children}
     </>
   );
 }

--- a/src/components/Layout/HeaderLayout/index.tsx
+++ b/src/components/Layout/HeaderLayout/index.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from "react";
+
+interface HeaderLayoutProps {
+  children: ReactNode;
+}
+
+function HeaderLayout({ children }: HeaderLayoutProps) {
+  return (
+    <>
+      <header>추후 헤더 완성되면 만들어진 헤더 사용 예정 </header>
+      <main>{children}</main>
+    </>
+  );
+}
+
+export default HeaderLayout;

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,13 +1,22 @@
 import type { AppProps } from "next/app";
+import { NextPage } from "next/types";
 
-import { useState } from "react";
+import { ReactElement, ReactNode, useState } from "react";
 
 import { Global } from "@emotion/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import reset from "@/styles/reset";
 
-export default function App({ Component, pageProps }: AppProps) {
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+interface AppPropsWithLayout extends AppProps {
+  Component: NextPageWithLayout; // components 속성이 NextPageWithLayout 타입을 따르도록 변경
+}
+
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -22,10 +31,12 @@ export default function App({ Component, pageProps }: AppProps) {
       }),
   );
 
+  const getLayout = Component.getLayout ?? ((page) => page);
+
   return (
     <QueryClientProvider client={queryClient}>
       <Global styles={reset} />
-      <Component {...pageProps} />
+      {getLayout(<Component {...pageProps} />)}
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
# 🎯 이슈 번호

- #13 

## 🏁 작업 내용(필수)

- 레이아웃 작업을 추가하였습니다.

## 💬 리뷰 요구 사항(선택)
- 헤더를 유라님이 맡아주셔서 헤더 만드시면 `HeaderLayout/index.tsx`에 반영해주시면 될 것 같습니다!
- 지금 디자인 상으로는 전역적으로 헤더를 사용해도 무방하긴 한데 나중에 헤더 안쓰는 페이지가 늘어나면 유지보수하기 힘들 것 같아서 레이아웃을 분리하였습니다.
```tsx
// 전역적으로 헤더 사용
export default function App({ Component, pageProps }: AppPropsWithLayout) {
  return (
      <Header>
         {<Component {...pageProps} />}
      </Header>
  );
}
```

## 📢 참고 사항(선택)
- 레이아웃 사용법(https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts)
```tsx
import HeaderLayout from '../components/layout/HeaderLayout';
 
export default function ExamplePage() {
  return (
    // 페이지 컴포넌트
  )
}
 
ExamplePage.getLayout = function getLayout(page) {
  return <HeaderLayout>{page}</HeaderLayout>
}
```
